### PR TITLE
Don't remove the last digit of the week for Välfärden

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -267,7 +267,7 @@ const sources: { [key: string]: (m: moment.Moment) => Promise<SimpleArrayData | 
     
     const weekNode = $('h2:contains(Vecka)');
     
-    if (weekNode.text().split(' ')[1].slice(0, -1) !== m.week().toString())
+    if (weekNode.text().split(' ')[1] !== m.week().toString())
       throw new Error('Wrong week');
 
     const dayNodes = weekNode.siblings().toArray().map(e => $(e).text());


### PR DESCRIPTION
Not sure what the `slice` was for in the first place. Maybe this could be done using a regex or a call to `trim` instead to make it more robust.